### PR TITLE
Add link to the blog to the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Please read through the [Code Of Conduct](./CODE_OF_CONDUCT.md) to make sure you
 
 - First make sure you meet all the [pre-requisites for running a Jekyll project outlined on their Quickstart page](https://jekyllrb.com/docs/)
 - `jekyll build` will build the project
-- `jekyll serve` will serve the project, and it will be accessible at `localhost:4000` (just put that in your browsers address bar to see)
+- `jekyll serve` will serve the project, and it will be accessible at [localhost:4000](http://localhost:4000/).
 
 ## Need to contact us?
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# The DDD East Midlands Blog.
+# The DDD East Midlands Blog
 
-Welcome to the repository for the DDD East Midlands Blog Page!
+Welcome to the repository for the [DDD East Midlands Blog](https://blog.dddeastmidlands.com/)!
 
-After much persuasion from the community, we have decided to move away from Medium and host our blogs using [Jekyll](https://jekyllrb.com/). 
+After much persuasion from the community, we have decided to move away from Medium and host our blogs using [Jekyll](https://jekyllrb.com/).
 
 We chose Jekyll as it is a framework we, the organisers, are familiar with and it allows posts to be submitted in markdown, which we hope will still keep the barrier to entry low.
 
@@ -22,6 +22,6 @@ Please read through the [Code Of Conduct](./CODE_OF_CONDUCT.md) to make sure you
 
 ## Need to contact us?
 
-Email jessica {at} dddeastmidlands.com 
+Email jessica {at} dddeastmidlands.com
 
 Jessica (co-organiser of DDD East Midlands) will get back to you as soon as she is able.


### PR DESCRIPTION
## Description of change
When coming across this repository (via Twitter) I could not see a link to the actual blog, so this commit adds a link.

It might also be worth adding a link to the blog in the description for the repo, as that was the first place I looked?

## Authors
Anna Shipman @annashipman