### PR TITLE
Add docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Please read through the [Code Of Conduct](./CODE_OF_CONDUCT.md) to make sure you
 
 Install docker following the [official steps here](https://docs.docker.com/get-started/) and then run:
 - `docker-compose up`
-- docker will run `jekyll serve` so the site will be accessible at [localhost:4000](http://localhost:4000/).
+- docker will run `jekyll serve` so you can modify files and the site will rebuild in docker.
+- The site will be accessible at [localhost:4000](http://localhost:4000/).
 
 ## Need to contact us?
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Please read through the [Code Of Conduct](./CODE_OF_CONDUCT.md) to make sure you
 - `jekyll build` will build the project
 - `jekyll serve` will serve the project, and it will be accessible at [localhost:4000](http://localhost:4000/).
 
+### Using Docker
+
+Install docker following the [official steps here](https://docs.docker.com/get-started/) and then run:
+- `docker-compose up`
+- docker will run `jekyll serve` so the site will be accessible at [localhost:4000](http://localhost:4000/).
+
 ## Need to contact us?
 
 Email jessica {at} dddeastmidlands.com

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+
+services:
+  jekyll:
+    image: jekyll/jekyll:3.8
+    command: jekyll serve --watch --incremental
+    ports:
+      - 4000:4000
+    volumes:
+      - .:/srv/jekyll
+


### PR DESCRIPTION
## Description of change
 New docker compose file

- To use docker locally, you can now use `docker-compose up`
- Set to pull in the version of Jekyll the site's using
- Watches for changes in local files and rebuilds the site
- Site available on port 4000
- Closes #34

## Authors
Anna Dodson @AnnaDodson 