### PR TITLE
refactor: Removes jquery and replaces it with a seperate JS file

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -45,29 +45,8 @@
 </footer>
 
 <!-- Scripts -->
-<script src="//code.jquery.com/jquery-1.11.2.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.5/highlight.min.js"></script>
-<script src="//cdnjs.cloudflare.com/ajax/libs/lightbox2/2.7.1/js/lightbox.min.js"></script>
-
-<script type="text/javascript">
-$(document).ready(function() {
-  // Default syntax highlighting
-  hljs.initHighlightingOnLoad();
-
-  // Header
-  var menuToggle = $('#js-mobile-menu').unbind();
-  $('#js-navigation-menu').removeClass("show");
-  menuToggle.on('click', function(e) {
-    e.preventDefault();
-    $('#js-navigation-menu').slideToggle(function(){
-      if($('#js-navigation-menu').is(':hidden')) {
-        $('#js-navigation-menu').removeAttr('style');
-      }
-    });
-  });
-});
-
-</script>
+<script src='/js/main.js' type="text/javascript"></script>
 
 {% if page.custom_js %}
 <!-- Custom page specific js files -->

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,11 @@
+document.addEventListener('DOMContentLoaded', (event) => {
+    document.querySelectorAll('pre code').forEach((block) => {
+      hljs.highlightBlock(block);
+    });
+    var navigationMenu = document.getElementById('js-navigation-menu')
+    navigationMenu.classList.remove('show')
+    var menuToggle = document.getElementById('js-mobile-menu')
+    menuToggle.addEventListener('click', function() {
+      navigationMenu.classList.toggle('show')
+    })
+  });


### PR DESCRIPTION
## Description of change
* Removes jQuery from footer.js
* Replaces functionality with vanilla JS
* Moved JS to a seperate file

## Authors
John Nolan (me@johnnolan.dev)

## Note to site owners
Double check that the implementation is okay. The saving in data to the user is great but I am not sure if the abruptness is worth it, but that call is up to you.