### PR TITLE
Invalidate CloudFront on deploys

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,3 +37,7 @@ jobs:
       run: |
         aws s3 sync ./_site/ s3://blog.dddeastmidlands.com/  --delete
         echo "Deployed to S3"
+    - name: Invalidate CloudFront cache
+      run: |
+        aws cloudfront create-invalidation --distribution-id E26XUC33RGAXEU --paths "/*"
+        echo 'Invalidated CloudFront cache'


### PR DESCRIPTION
## Description of change

To prevent issues with caching on clients post-deployment, we need to
invalidate the CloudFront cache, otherwise folks won't be able to see
i.e. uploaded photos for Hacktoberfest.

## Authors

@jamietanna 