### PR TITLE
Accessibility improved

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,4 +1,5 @@
 <footer class="site-footer">
+  <a class="wcag-link" href="#main">Jump back to the main content</a>
 
   <div class="wrapper">
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,4 +1,5 @@
 <header class="navigation" role="banner">
+  <a class="wcag-link" href="#main">Skip to the main content</a>
   <div class="navigation-wrapper">
     <a href="{{ site.baseurl }}/" class="logo">
       {% if site.logo %}
@@ -10,7 +11,7 @@
     <a href="javascript:void(0)" class="navigation-menu-button" id="js-mobile-menu">
       <i class="fa fa-bars"></i>
     </a>
-    <nav role="navigation">
+    <nav role="navigation" aria-label="Main Menu" id='main-menu'>
       <ul id="js-navigation-menu" class="navigation-menu show">
         <li class="nav-link"><a href="{{ site.baseurl }}/">Blog</a>
         <li class="nav-link"><a href="https://www.dddeastmidlands.com" target="_blank">DDDEM Website</a>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,9 +7,9 @@
 
     {% include header.html %}
 
-    <div class="page-content">
+    <main class="page-content" id="main">
         {{ content }}
-    </div>
+    </main>
 
     {% include footer.html %}
 

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -221,7 +221,7 @@ pre code.hljs {
 		font-family: 'Montserrat';
 	  }
 	  
-	  .button:hover {
+	  .button:hover, .button:focus {
 		border: 2px solid #c01439;
 		color: #c01439;
 	  }
@@ -481,4 +481,43 @@ pre code.hljs {
     height: 128px;
     width: 128px;
   }
+}
+
+// adding accesablility compliant focus
+//When the user is not actively focusing the quick-link, hide it.
+.wcag-link{
+	opacity: 0;
+	z-index:-1;
+	display: inline-block;
+	background-color: white;
+	position: fixed;
+	top:20px;
+	left:50%;
+	transform: translate(-50% , 0);
+	padding: 20px 10px;
+	border:solid 3px $highlight-color;
+}
+footer .wcag-link{
+	bottom:200px;
+	top:unset;
+}
+
+.user-is-tabbing{
+	.logo {
+		float: left;
+		&:focus-within{
+			-webkit-box-shadow: inset 0px 0px 5px 5px #c01439;
+			-moz-box-shadow: inset 0px 0px 5px 5px #c01439;
+			box-shadow: inset 0px 0px 5px 5px #c01439;
+		}
+	}
+	.button:focus{
+		-webkit-box-shadow: inset 0px 0px 5px 5px #c01439;
+		-moz-box-shadow: inset 0px 0px 5px 5px #c01439;
+		box-shadow: inset 0px 0px 5px 5px #c01439;
+	}
+	.wcag-link:focus{
+		opacity: 1;
+		z-index:999;
+	}
 }

--- a/js/main.js
+++ b/js/main.js
@@ -9,3 +9,21 @@ document.addEventListener('DOMContentLoaded', (event) => {
       navigationMenu.classList.toggle('show')
     })
   });
+  
+  
+function handleFirstTab(e) {
+  if (e.keyCode === 9) {
+    document.body.classList.add('user-is-tabbing');
+    window.removeEventListener('keydown', handleFirstTab);
+    window.addEventListener('mousedown', handleMouseDownOnce);
+  }
+}
+
+function handleMouseDownOnce() {
+  document.body.classList.remove('user-is-tabbing');
+  
+  window.removeEventListener('mousedown', handleMouseDownOnce);
+  window.addEventListener('keydown', handleFirstTab);
+}
+
+window.addEventListener('keydown', handleFirstTab);


### PR DESCRIPTION
## Description of change

Related to issue: #43 and #7.

- Added some better highlighting to certain elements when using tab to navigate the site.
- Added Javascript handler to detect when a user is using their keyboard and when they are not.
- Added quick links to skip the main menu and footer when using the keyboard to navigate.

### Possible improvements

- The red highlight color has a to low of a contrast compared to the footer (1.27:1). A contrast ratio of at least 4.5:1 is to recommend.
- When browsing in mobile mode, different aria-labels could be added to the main menu to notate that is has a drop-down and that the underlying links are hidden.
- The function of the category filter buttons are not clear. Making it clear that you can filter posts via the buttons would be good.
- A secondary way to find content would be nice. A search function for example.
- Minor improvement. The alt-attribute of some images are really generic. The ddd-logotype for example. It's market as just 'logo'. There really isn't any limit to how long of a text you can add to an alt-tag, but you can also add an longdesc-tag to the images.

## Authors
-- Linus Johansson @RedLinus  --