### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,6 @@
 name: DDDEMBlog Deploy
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/DDDEastMidlandsLimited/dddem-blog/security/code-scanning/4](https://github.com/DDDEastMidlandsLimited/dddem-blog/security/code-scanning/4)

To fix the problem, add a `permissions` block to the workflow file to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow does not interact with the repository (e.g., pushing code, creating issues, or PRs), the minimal permission of `contents: read` is sufficient. This can be set at the workflow level (top-level, after `name:` and before `on:`) to apply to all jobs, or at the job level if only specific jobs need it. The best practice is to set it at the workflow level for clarity and to ensure all jobs inherit the restriction unless overridden.  
**Change:**  
- Insert the following after the `name:` line and before the `on:` block in `.github/workflows/main.yml`:
  ```yaml
  permissions:
    contents: read
  ```
No additional methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
